### PR TITLE
Filter out placeholders from `crates.io`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "psvm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psvm"
-version = "0.2.1"
+version = "0.2.2"
 description = "A tool to manage and update the Polkadot SDK dependencies in any Cargo.toml file."
 repository = "https://github.com/paritytech/psvm"
 authors = ["Parity Technologies <admin@parity.io>", "Patricio (patriciobcs)"]

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -190,7 +190,7 @@ pub async fn get_release_branches_versions() -> Result<Vec<String>, Box<dyn std:
 
 pub async fn get_parity_crate_owner_crates() -> Result<HashSet<String>, Box<dyn std::error::Error>>
 {
-    let mut crates = HashSet::new();
+    let mut parity_crates = HashSet::new();
 
     for page in 1..=10 {
         // Currently there are 7 pages (so this at most 1s)
@@ -208,20 +208,23 @@ pub async fn get_parity_crate_owner_crates() -> Result<HashSet<String>, Box<dyn 
 
         let crates_data: serde_json::Value = serde_json::from_str(&output)?;
 
-        let crate_names = crates_data["crates"]
+        let crates = crates_data["crates"]
             .as_array()
             .unwrap()
-            .iter()
+            .iter();
+
+        let crates_len = crates.len();
+
+        let crate_names = crates
+            .filter(|crate_data| crate_data["max_version"].as_str().unwrap_or_default().to_string() != "0.0.0")
             .map(|crate_data| crate_data["id"].as_str().unwrap_or_default().to_string());
 
-        let crates_len = crate_names.len();
-
-        crates.extend(crate_names);
+        parity_crates.extend(crate_names);
 
         if crates_len < 100 {
             break;
         }
     }
 
-    Ok(crates)
+    Ok(parity_crates)
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -216,7 +216,7 @@ pub async fn get_parity_crate_owner_crates() -> Result<HashSet<String>, Box<dyn 
         let crates_len = crates.len();
 
         let crate_names = crates
-            .filter(|crate_data| crate_data["max_version"].as_str().unwrap_or_default().to_string() != "0.0.0")
+            .filter(|crate_data| crate_data["max_version"].as_str().unwrap_or_default() != "0.0.0")
             .map(|crate_data| crate_data["id"].as_str().unwrap_or_default().to_string());
 
         parity_crates.extend(crate_names);


### PR DESCRIPTION
The current implementation [filters out](https://github.com/paritytech/psvm/blob/a1bf3921f0b3dce2d25eada4594cc8763b2cec02/src/versions.rs#L113) placeholders from `Plan.toml`.

There is however a problem with placeholders that are NOT marked as `0.0.0` in `Plan.toml`, but should not be treated as valid crates.

For example: [pallet-parachain-template](https://github.com/paritytech/polkadot-sdk/blob/a21bd2ee80665d99083df440428426ea71b60cce/Plan.toml#L1453-L1455) is not filtered out as a placeholder, but should be - all its [versions have been yanked](https://crates.io/crates/pallet-parachain-template/versions).

This change filters out packages from `crates.io` that have `max_version` as `0.0.0` - so they are just placeholders.