### PR TITLE
fix logic of code based on variable names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &cargo_toml_path,
         &crates_versions,
         cmd.overwrite,
-        !cmd.check,
+        cmd.check,
     )?;
 
     Ok(())
@@ -150,9 +150,9 @@ fn update_dependencies_impl(
     let new_content = cargo_toml.to_string();
     if new_content != cargo_toml_content {
         if only_check {
-            Ok(Some(new_content))
-        } else {
             Err("Dependencies are not up to date".into())
+        } else {
+            Ok(Some(new_content))
         }
     } else {
         Ok(None)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -29,7 +29,7 @@ mod tests {
 
         // Call the refactored logic function with the test data
         let result =
-            crate::update_dependencies_impl(&input_cargo_toml_path, &crates_versions, false, true)
+            crate::update_dependencies_impl(&input_cargo_toml_path, &crates_versions, false, false)
                 .unwrap();
 
         // Assert that the result matches the expected output
@@ -46,7 +46,7 @@ mod tests {
 
         // Call the refactored logic function with the test data
         let result =
-            crate::update_dependencies_impl(&input_cargo_toml_path, &crates_versions, false, false);
+            crate::update_dependencies_impl(&input_cargo_toml_path, &crates_versions, false, true);
 
         result
     }
@@ -230,7 +230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
                 &input_cargo_toml_path,
                 &crates_versions,
                 false,
-                true,
+                false,
             )
             .unwrap();
 


### PR DESCRIPTION
The variable name was changed from `update` to `only_check`, which essentially has it represent the opposite value, but the code was not updated to reflect that new name change.

This PR changes the logic so when `only_check` is true, we execute the `check` command.