### PR TITLE
Added the --orml flag to view available ORML versions and update the ORML crates in Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you want to update the dependencies to a specific Polkadot SDK version, you c
 
 If you want to check if the dependencies in your local Cargo.toml file are matching to a specific Polkadot SDK version, you can use the `-c` or `--check` flag along with the `--version` flag followed by the version you want to check against.
 
-If you want to update the ORML crates in your local Cargo.toml, you can use the `-O` or `--orml` flag along with the `--version` flag to update the ORML crates along with the polkadot-sdk crates. [This works only if the supplied version is present in the ORML releases.]
+If you want to update the ORML crates in your local Cargo.toml, you can use the `-O` or `--orml` flag along with the `--version` flag to update the ORML crates along with the polkadot-sdk crates. This works only if the supplied version is present in the ORML releases.
 
 ```sh
 # Go to the directory containing the Cargo.toml file you want to update

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ If you want to update the dependencies to a specific Polkadot SDK version, you c
 
 If you want to check if the dependencies in your local Cargo.toml file are matching to a specific Polkadot SDK version, you can use the `-c` or `--check` flag along with the `--version` flag followed by the version you want to check against.
 
+If you want to update the ORML crates in your local Cargo.toml, you can use the `-O` or `--orml` flag along with the `--version` flag to update the ORML crates along with the polkadot-sdk crates. [This works only if the supplied version is present in the ORML releases.]
+
 ```sh
 # Go to the directory containing the Cargo.toml file you want to update
 cd <cargo-toml-dir>
@@ -38,7 +40,9 @@ psvm -v "1.7.0" -o
 # List all available Polkadot SDK versions
 psvm -l
 # Check against a particular Polkadot SDK version without updating the Cargo.toml file
-psmv -v "1.4.0" -c
+psvm -v "1.4.0" -c
+# Update the ORML dependencies along with the Polkadot SDK dependencies.
+psvm -v "1.6.0" -O
 ```
 
 > Listing all available Polkadot SDK versions requires querying the GitHub API, so your IP may be rate-limited. If a rate limit is reached, the tool will fallback to the GitHub CLI to list the versions. Ensure you have the GitHub CLI installed and authenticated to avoid any issue.

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,13 +92,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut crates_versions: BTreeMap<String, String> =
         get_version_mapping_with_fallback(DEFAULT_GIT_SERVER, &version).await?;
 
-    let orml_crates_version = if cmd.orml {
-        get_orml_crates_and_version(DEFAULT_GIT_SERVER, &version).await?
-    } else {
-        None
-    };
-
-    include_orml_crates_in_version_mapping(&mut crates_versions, orml_crates_version);
+    if cmd.orml {
+        let orml_crates = get_orml_crates_and_version(DEFAULT_GIT_SERVER, &version).await?;
+        include_orml_crates_in_version_mapping(&mut crates_versions, orml_crates);
+    }
 
     update_dependencies(&cargo_toml_path, &crates_versions, cmd.overwrite, cmd.check)?;
 
@@ -240,5 +237,3 @@ pub fn update_table_dependencies(
         log::debug!("Setting {} to {}", dep_key_str, crate_version);
     }
 }
-
-// orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "release-polkadot-v1.1.0", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,16 +18,19 @@ mod versions;
 
 use clap::Parser;
 use env_logger::Env;
-use std::collections::BTreeMap;
-use std::fs;
-use std::path::Path;
-use std::path::PathBuf;
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{ Path, PathBuf, },
+};
 use toml_edit::DocumentMut;
-use versions::get_orml_crates_and_version;
-use versions::get_release_branches_versions;
-use versions::get_version_mapping_with_fallback;
-use versions::include_orml_crates_in_version_mapping;
-use versions::Repository;
+use versions::{
+    get_orml_crates_and_version,
+    get_release_branches_versions,
+    get_version_mapping_with_fallback,
+    include_orml_crates_in_version_mapping,
+    Repository,
+};
 
 pub const DEFAULT_GIT_SERVER: &str = "https://raw.githubusercontent.com";
 

--- a/src/testing/orml/input.Cargo.toml
+++ b/src/testing/orml/input.Cargo.toml
@@ -1,0 +1,182 @@
+[package]
+name = "runtime"
+version = "1.0.0"
+authors = ["Anonymous"]
+description = "A parachain runtime."
+license = "Unlicense"
+edition = 2021
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[build-dependencies]
+substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", optional = true, version = "14.0.0" }
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+hex-literal = { version = "0.4.1", optional = true }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+smallvec = "1.11.0"
+
+# Local
+pallet-parachain-template = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+
+# ORML
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-authority = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-nft = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+
+# Substrate
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false, optional = true }
+frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false, optional = true }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false, optional = true }
+pallet-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+sp-version = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+
+# Polkadot
+pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+polkadot-parachain-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+xcm-builder = { package = "staging-xcm-builder", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+xcm-executor = { package = "staging-xcm-executor", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+
+# Cumulus
+cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false, features = ["parameterized-consensus-hook"] }
+cumulus-pallet-session-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+pallet-collator-selection = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+parachain-info = { package = "staging-parachain-info", git = "https://github.com/paritytech/polkadot-sdk", branch = "release-crates-io-v1.3.0", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [
+	"codec/std",
+	"cumulus-pallet-aura-ext/std",
+	"cumulus-pallet-dmp-queue/std",
+	"cumulus-pallet-parachain-system/std",
+	"cumulus-pallet-session-benchmarking/std",
+	"cumulus-pallet-xcm/std",
+	"cumulus-pallet-xcmp-queue/std",
+	"cumulus-primitives-core/std",
+	"cumulus-primitives-utility/std",
+	"frame-benchmarking?/std",
+	"frame-executive/std",
+	"frame-support/std",
+	"frame-system-benchmarking?/std",
+	"frame-system-rpc-runtime-api/std",
+	"frame-system/std",
+	"frame-try-runtime?/std",
+	"log/std",
+	"pallet-aura/std",
+	"pallet-authorship/std",
+	"pallet-balances/std",
+	"pallet-collator-selection/std",
+	"pallet-parachain-template/std",
+	"pallet-session/std",
+	"pallet-sudo/std",
+	"pallet-timestamp/std",
+	"pallet-transaction-payment-rpc-runtime-api/std",
+	"pallet-transaction-payment/std",
+	"pallet-xcm/std",
+	"parachain-info/std",
+	"polkadot-parachain-primitives/std",
+	"polkadot-runtime-common/std",
+	"scale-info/std",
+	"sp-api/std",
+	"sp-block-builder/std",
+	"sp-consensus-aura/std",
+	"sp-core/std",
+	"sp-genesis-builder/std",
+	"sp-inherents/std",
+	"sp-offchain/std",
+	"sp-runtime/std",
+	"sp-session/std",
+	"sp-std/std",
+	"sp-transaction-pool/std",
+	"sp-version/std",
+	"substrate-wasm-builder",
+	"xcm-builder/std",
+	"xcm-executor/std",
+	"xcm/std",
+]
+
+runtime-benchmarks = [
+	"cumulus-pallet-parachain-system/runtime-benchmarks",
+	"cumulus-pallet-session-benchmarking/runtime-benchmarks",
+	"cumulus-pallet-xcmp-queue/runtime-benchmarks",
+	"cumulus-primitives-utility/runtime-benchmarks",
+	"frame-benchmarking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system-benchmarking/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"hex-literal",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-collator-selection/runtime-benchmarks",
+	"pallet-parachain-template/runtime-benchmarks",
+	"pallet-sudo/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks",
+	"pallet-xcm/runtime-benchmarks",
+	"polkadot-parachain-primitives/runtime-benchmarks",
+	"polkadot-runtime-common/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"xcm-builder/runtime-benchmarks",
+	"xcm-executor/runtime-benchmarks",
+]
+
+try-runtime = [
+	"cumulus-pallet-aura-ext/try-runtime",
+	"cumulus-pallet-dmp-queue/try-runtime",
+	"cumulus-pallet-parachain-system/try-runtime",
+	"cumulus-pallet-xcm/try-runtime",
+	"cumulus-pallet-xcmp-queue/try-runtime",
+	"frame-executive/try-runtime",
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"frame-try-runtime/try-runtime",
+	"pallet-aura/try-runtime",
+	"pallet-authorship/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-collator-selection/try-runtime",
+	"pallet-parachain-template/try-runtime",
+	"pallet-session/try-runtime",
+	"pallet-sudo/try-runtime",
+	"pallet-timestamp/try-runtime",
+	"pallet-transaction-payment/try-runtime",
+	"pallet-xcm/try-runtime",
+	"parachain-info/try-runtime",
+	"polkadot-runtime-common/try-runtime",
+	"sp-runtime/try-runtime",
+]
+
+experimental = [ "pallet-aura/experimental" ]

--- a/src/testing/orml/noFlag.Cargo.toml
+++ b/src/testing/orml/noFlag.Cargo.toml
@@ -1,0 +1,182 @@
+[package]
+name = "runtime"
+version = "1.0.0"
+authors = ["Anonymous"]
+description = "A parachain runtime."
+license = "Unlicense"
+edition = 2021
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[build-dependencies]
+substrate-wasm-builder = { version = "17.0.0", optional = true }
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+hex-literal = { version = "0.4.1", optional = true }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+smallvec = "1.11.0"
+
+# Local
+pallet-parachain-template = { version = "0.7.0", default-features = false }
+
+# ORML
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-authority = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-nft = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+
+# Substrate
+frame-benchmarking = { version = "28.0.0", default-features = false, optional = true }
+frame-executive = { version = "28.0.0", default-features = false }
+frame-support = { version = "28.0.0", default-features = false }
+frame-system = { version = "28.0.0", default-features = false }
+frame-system-benchmarking = { version = "28.0.0", default-features = false, optional = true }
+frame-system-rpc-runtime-api = { version = "26.0.0", default-features = false }
+frame-try-runtime = { version = "0.34.0", default-features = false, optional = true }
+pallet-aura = { version = "27.0.0", default-features = false }
+pallet-authorship = { version = "28.0.0", default-features = false }
+pallet-balances = { version = "28.0.0", default-features = false }
+pallet-session = { version = "28.0.0", default-features = false }
+pallet-sudo = { version = "28.0.0", default-features = false }
+pallet-timestamp = { version = "27.0.0", default-features = false }
+pallet-transaction-payment = { version = "28.0.0", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { version = "28.0.0", default-features = false }
+sp-api = { version = "26.0.0", default-features = false }
+sp-block-builder = { version = "26.0.0", default-features = false }
+sp-consensus-aura = { version = "0.32.0", default-features = false }
+sp-core = { version = "28.0.0", default-features = false }
+sp-genesis-builder = { version = "0.7.0", default-features = false }
+sp-inherents = { version = "26.0.0", default-features = false }
+sp-offchain = { version = "26.0.0", default-features = false }
+sp-runtime = { version = "31.0.0", default-features = false }
+sp-session = { version = "27.0.0", default-features = false }
+sp-std = { version = "14.0.0", default-features = false }
+sp-transaction-pool = { version = "26.0.0", default-features = false }
+sp-version = { version = "29.0.0", default-features = false }
+
+# Polkadot
+pallet-xcm = { version = "7.0.0", default-features = false }
+polkadot-parachain-primitives = { version = "6.0.0", default-features = false }
+polkadot-runtime-common = { version = "7.0.0", default-features = false }
+xcm = { version = "7.0.0", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "7.0.3", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "7.0.3", package = "staging-xcm-executor", default-features = false }
+
+# Cumulus
+cumulus-pallet-aura-ext = { version = "0.7.0", default-features = false }
+cumulus-pallet-dmp-queue = { version = "0.7.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.7.0", default-features = false, features = ["parameterized-consensus-hook"] }
+cumulus-pallet-session-benchmarking = { version = "9.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.7.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.7.0", default-features = false }
+cumulus-primitives-core = { version = "0.7.0", default-features = false }
+cumulus-primitives-utility = { version = "0.7.3", default-features = false }
+pallet-collator-selection = { version = "9.0.2", default-features = false }
+parachain-info = { version = "0.7.0", package = "staging-parachain-info", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [
+	"codec/std",
+	"cumulus-pallet-aura-ext/std",
+	"cumulus-pallet-dmp-queue/std",
+	"cumulus-pallet-parachain-system/std",
+	"cumulus-pallet-session-benchmarking/std",
+	"cumulus-pallet-xcm/std",
+	"cumulus-pallet-xcmp-queue/std",
+	"cumulus-primitives-core/std",
+	"cumulus-primitives-utility/std",
+	"frame-benchmarking?/std",
+	"frame-executive/std",
+	"frame-support/std",
+	"frame-system-benchmarking?/std",
+	"frame-system-rpc-runtime-api/std",
+	"frame-system/std",
+	"frame-try-runtime?/std",
+	"log/std",
+	"pallet-aura/std",
+	"pallet-authorship/std",
+	"pallet-balances/std",
+	"pallet-collator-selection/std",
+	"pallet-parachain-template/std",
+	"pallet-session/std",
+	"pallet-sudo/std",
+	"pallet-timestamp/std",
+	"pallet-transaction-payment-rpc-runtime-api/std",
+	"pallet-transaction-payment/std",
+	"pallet-xcm/std",
+	"parachain-info/std",
+	"polkadot-parachain-primitives/std",
+	"polkadot-runtime-common/std",
+	"scale-info/std",
+	"sp-api/std",
+	"sp-block-builder/std",
+	"sp-consensus-aura/std",
+	"sp-core/std",
+	"sp-genesis-builder/std",
+	"sp-inherents/std",
+	"sp-offchain/std",
+	"sp-runtime/std",
+	"sp-session/std",
+	"sp-std/std",
+	"sp-transaction-pool/std",
+	"sp-version/std",
+	"substrate-wasm-builder",
+	"xcm-builder/std",
+	"xcm-executor/std",
+	"xcm/std",
+]
+
+runtime-benchmarks = [
+	"cumulus-pallet-parachain-system/runtime-benchmarks",
+	"cumulus-pallet-session-benchmarking/runtime-benchmarks",
+	"cumulus-pallet-xcmp-queue/runtime-benchmarks",
+	"cumulus-primitives-utility/runtime-benchmarks",
+	"frame-benchmarking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system-benchmarking/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"hex-literal",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-collator-selection/runtime-benchmarks",
+	"pallet-parachain-template/runtime-benchmarks",
+	"pallet-sudo/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks",
+	"pallet-xcm/runtime-benchmarks",
+	"polkadot-parachain-primitives/runtime-benchmarks",
+	"polkadot-runtime-common/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"xcm-builder/runtime-benchmarks",
+	"xcm-executor/runtime-benchmarks",
+]
+
+try-runtime = [
+	"cumulus-pallet-aura-ext/try-runtime",
+	"cumulus-pallet-dmp-queue/try-runtime",
+	"cumulus-pallet-parachain-system/try-runtime",
+	"cumulus-pallet-xcm/try-runtime",
+	"cumulus-pallet-xcmp-queue/try-runtime",
+	"frame-executive/try-runtime",
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"frame-try-runtime/try-runtime",
+	"pallet-aura/try-runtime",
+	"pallet-authorship/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-collator-selection/try-runtime",
+	"pallet-parachain-template/try-runtime",
+	"pallet-session/try-runtime",
+	"pallet-sudo/try-runtime",
+	"pallet-timestamp/try-runtime",
+	"pallet-transaction-payment/try-runtime",
+	"pallet-xcm/try-runtime",
+	"parachain-info/try-runtime",
+	"polkadot-runtime-common/try-runtime",
+	"sp-runtime/try-runtime",
+]
+
+experimental = [ "pallet-aura/experimental" ]

--- a/src/testing/orml/notOrml.Cargo.toml
+++ b/src/testing/orml/notOrml.Cargo.toml
@@ -1,0 +1,182 @@
+[package]
+name = "runtime"
+version = "1.0.0"
+authors = ["Anonymous"]
+description = "A parachain runtime."
+license = "Unlicense"
+edition = 2021
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[build-dependencies]
+substrate-wasm-builder = { version = "23.0.0", optional = true }
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+hex-literal = { version = "0.4.1", optional = true }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+smallvec = "1.11.0"
+
+# Local
+pallet-parachain-template = { version = "0.1.0", default-features = false }
+
+# ORML
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-authority = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-nft = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v1.1.0", default-features = false }
+
+# Substrate
+frame-benchmarking = { version = "36.0.0", default-features = false, optional = true }
+frame-executive = { version = "36.0.0", default-features = false }
+frame-support = { version = "36.0.0", default-features = false }
+frame-system = { version = "36.0.0", default-features = false }
+frame-system-benchmarking = { version = "36.0.0", default-features = false, optional = true }
+frame-system-rpc-runtime-api = { version = "33.0.0", default-features = false }
+frame-try-runtime = { version = "0.42.0", default-features = false, optional = true }
+pallet-aura = { version = "35.0.0", default-features = false }
+pallet-authorship = { version = "36.0.0", default-features = false }
+pallet-balances = { version = "37.0.0", default-features = false }
+pallet-session = { version = "36.0.0", default-features = false }
+pallet-sudo = { version = "36.0.0", default-features = false }
+pallet-timestamp = { version = "35.0.0", default-features = false }
+pallet-transaction-payment = { version = "36.0.0", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { version = "36.0.0", default-features = false }
+sp-api = { version = "33.0.0", default-features = false }
+sp-block-builder = { version = "33.0.0", default-features = false }
+sp-consensus-aura = { version = "0.39.0", default-features = false }
+sp-core = { version = "34.0.0", default-features = false }
+sp-genesis-builder = { version = "0.14.0", default-features = false }
+sp-inherents = { version = "33.0.0", default-features = false }
+sp-offchain = { version = "33.0.0", default-features = false }
+sp-runtime = { version = "38.0.0", default-features = false }
+sp-session = { version = "34.0.0", default-features = false }
+sp-std = { version = "14.0.0", default-features = false }
+sp-transaction-pool = { version = "33.0.0", default-features = false }
+sp-version = { version = "36.0.0", default-features = false }
+
+# Polkadot
+pallet-xcm = { version = "15.0.0", default-features = false }
+polkadot-parachain-primitives = { version = "13.0.0", default-features = false }
+polkadot-runtime-common = { version = "15.0.0", default-features = false }
+xcm = { version = "14.0.1", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "15.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "15.0.0", package = "staging-xcm-executor", default-features = false }
+
+# Cumulus
+cumulus-pallet-aura-ext = { version = "0.15.0", default-features = false }
+cumulus-pallet-dmp-queue = { version = "0.15.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.15.0", default-features = false, features = ["parameterized-consensus-hook"] }
+cumulus-pallet-session-benchmarking = { version = "17.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.15.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.15.0", default-features = false }
+cumulus-primitives-core = { version = "0.14.0", default-features = false }
+cumulus-primitives-utility = { version = "0.15.0", default-features = false }
+pallet-collator-selection = { version = "17.0.0", default-features = false }
+parachain-info = { version = "0.15.0", package = "staging-parachain-info", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [
+	"codec/std",
+	"cumulus-pallet-aura-ext/std",
+	"cumulus-pallet-dmp-queue/std",
+	"cumulus-pallet-parachain-system/std",
+	"cumulus-pallet-session-benchmarking/std",
+	"cumulus-pallet-xcm/std",
+	"cumulus-pallet-xcmp-queue/std",
+	"cumulus-primitives-core/std",
+	"cumulus-primitives-utility/std",
+	"frame-benchmarking?/std",
+	"frame-executive/std",
+	"frame-support/std",
+	"frame-system-benchmarking?/std",
+	"frame-system-rpc-runtime-api/std",
+	"frame-system/std",
+	"frame-try-runtime?/std",
+	"log/std",
+	"pallet-aura/std",
+	"pallet-authorship/std",
+	"pallet-balances/std",
+	"pallet-collator-selection/std",
+	"pallet-parachain-template/std",
+	"pallet-session/std",
+	"pallet-sudo/std",
+	"pallet-timestamp/std",
+	"pallet-transaction-payment-rpc-runtime-api/std",
+	"pallet-transaction-payment/std",
+	"pallet-xcm/std",
+	"parachain-info/std",
+	"polkadot-parachain-primitives/std",
+	"polkadot-runtime-common/std",
+	"scale-info/std",
+	"sp-api/std",
+	"sp-block-builder/std",
+	"sp-consensus-aura/std",
+	"sp-core/std",
+	"sp-genesis-builder/std",
+	"sp-inherents/std",
+	"sp-offchain/std",
+	"sp-runtime/std",
+	"sp-session/std",
+	"sp-std/std",
+	"sp-transaction-pool/std",
+	"sp-version/std",
+	"substrate-wasm-builder",
+	"xcm-builder/std",
+	"xcm-executor/std",
+	"xcm/std",
+]
+
+runtime-benchmarks = [
+	"cumulus-pallet-parachain-system/runtime-benchmarks",
+	"cumulus-pallet-session-benchmarking/runtime-benchmarks",
+	"cumulus-pallet-xcmp-queue/runtime-benchmarks",
+	"cumulus-primitives-utility/runtime-benchmarks",
+	"frame-benchmarking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system-benchmarking/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"hex-literal",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-collator-selection/runtime-benchmarks",
+	"pallet-parachain-template/runtime-benchmarks",
+	"pallet-sudo/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks",
+	"pallet-xcm/runtime-benchmarks",
+	"polkadot-parachain-primitives/runtime-benchmarks",
+	"polkadot-runtime-common/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"xcm-builder/runtime-benchmarks",
+	"xcm-executor/runtime-benchmarks",
+]
+
+try-runtime = [
+	"cumulus-pallet-aura-ext/try-runtime",
+	"cumulus-pallet-dmp-queue/try-runtime",
+	"cumulus-pallet-parachain-system/try-runtime",
+	"cumulus-pallet-xcm/try-runtime",
+	"cumulus-pallet-xcmp-queue/try-runtime",
+	"frame-executive/try-runtime",
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"frame-try-runtime/try-runtime",
+	"pallet-aura/try-runtime",
+	"pallet-authorship/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-collator-selection/try-runtime",
+	"pallet-parachain-template/try-runtime",
+	"pallet-session/try-runtime",
+	"pallet-sudo/try-runtime",
+	"pallet-timestamp/try-runtime",
+	"pallet-transaction-payment/try-runtime",
+	"pallet-xcm/try-runtime",
+	"parachain-info/try-runtime",
+	"polkadot-runtime-common/try-runtime",
+	"sp-runtime/try-runtime",
+]
+
+experimental = [ "pallet-aura/experimental" ]

--- a/src/testing/orml/output.Cargo.toml
+++ b/src/testing/orml/output.Cargo.toml
@@ -1,0 +1,182 @@
+[package]
+name = "runtime"
+version = "1.0.0"
+authors = ["Anonymous"]
+description = "A parachain runtime."
+license = "Unlicense"
+edition = 2021
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[build-dependencies]
+substrate-wasm-builder = { version = "17.0.0", optional = true }
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+hex-literal = { version = "0.4.1", optional = true }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+smallvec = "1.11.0"
+
+# Local
+pallet-parachain-template = { version = "0.7.0", default-features = false }
+
+# ORML
+orml-tokens = { version = "0.7.0", default-features = false }
+orml-xcm = { version = "0.7.0", default-features = false }
+orml-authority = { version = "0.7.0", default-features = false }
+orml-nft = { version = "0.7.0", default-features = false }
+orml-xtokens = { version = "0.7.0", default-features = false }
+
+# Substrate
+frame-benchmarking = { version = "28.0.0", default-features = false, optional = true }
+frame-executive = { version = "28.0.0", default-features = false }
+frame-support = { version = "28.0.0", default-features = false }
+frame-system = { version = "28.0.0", default-features = false }
+frame-system-benchmarking = { version = "28.0.0", default-features = false, optional = true }
+frame-system-rpc-runtime-api = { version = "26.0.0", default-features = false }
+frame-try-runtime = { version = "0.34.0", default-features = false, optional = true }
+pallet-aura = { version = "27.0.0", default-features = false }
+pallet-authorship = { version = "28.0.0", default-features = false }
+pallet-balances = { version = "28.0.0", default-features = false }
+pallet-session = { version = "28.0.0", default-features = false }
+pallet-sudo = { version = "28.0.0", default-features = false }
+pallet-timestamp = { version = "27.0.0", default-features = false }
+pallet-transaction-payment = { version = "28.0.0", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { version = "28.0.0", default-features = false }
+sp-api = { version = "26.0.0", default-features = false }
+sp-block-builder = { version = "26.0.0", default-features = false }
+sp-consensus-aura = { version = "0.32.0", default-features = false }
+sp-core = { version = "28.0.0", default-features = false }
+sp-genesis-builder = { version = "0.7.0", default-features = false }
+sp-inherents = { version = "26.0.0", default-features = false }
+sp-offchain = { version = "26.0.0", default-features = false }
+sp-runtime = { version = "31.0.0", default-features = false }
+sp-session = { version = "27.0.0", default-features = false }
+sp-std = { version = "14.0.0", default-features = false }
+sp-transaction-pool = { version = "26.0.0", default-features = false }
+sp-version = { version = "29.0.0", default-features = false }
+
+# Polkadot
+pallet-xcm = { version = "7.0.0", default-features = false }
+polkadot-parachain-primitives = { version = "6.0.0", default-features = false }
+polkadot-runtime-common = { version = "7.0.0", default-features = false }
+xcm = { version = "7.0.0", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "7.0.3", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "7.0.3", package = "staging-xcm-executor", default-features = false }
+
+# Cumulus
+cumulus-pallet-aura-ext = { version = "0.7.0", default-features = false }
+cumulus-pallet-dmp-queue = { version = "0.7.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.7.0", default-features = false, features = ["parameterized-consensus-hook"] }
+cumulus-pallet-session-benchmarking = { version = "9.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.7.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.7.0", default-features = false }
+cumulus-primitives-core = { version = "0.7.0", default-features = false }
+cumulus-primitives-utility = { version = "0.7.3", default-features = false }
+pallet-collator-selection = { version = "9.0.2", default-features = false }
+parachain-info = { version = "0.7.0", package = "staging-parachain-info", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [
+	"codec/std",
+	"cumulus-pallet-aura-ext/std",
+	"cumulus-pallet-dmp-queue/std",
+	"cumulus-pallet-parachain-system/std",
+	"cumulus-pallet-session-benchmarking/std",
+	"cumulus-pallet-xcm/std",
+	"cumulus-pallet-xcmp-queue/std",
+	"cumulus-primitives-core/std",
+	"cumulus-primitives-utility/std",
+	"frame-benchmarking?/std",
+	"frame-executive/std",
+	"frame-support/std",
+	"frame-system-benchmarking?/std",
+	"frame-system-rpc-runtime-api/std",
+	"frame-system/std",
+	"frame-try-runtime?/std",
+	"log/std",
+	"pallet-aura/std",
+	"pallet-authorship/std",
+	"pallet-balances/std",
+	"pallet-collator-selection/std",
+	"pallet-parachain-template/std",
+	"pallet-session/std",
+	"pallet-sudo/std",
+	"pallet-timestamp/std",
+	"pallet-transaction-payment-rpc-runtime-api/std",
+	"pallet-transaction-payment/std",
+	"pallet-xcm/std",
+	"parachain-info/std",
+	"polkadot-parachain-primitives/std",
+	"polkadot-runtime-common/std",
+	"scale-info/std",
+	"sp-api/std",
+	"sp-block-builder/std",
+	"sp-consensus-aura/std",
+	"sp-core/std",
+	"sp-genesis-builder/std",
+	"sp-inherents/std",
+	"sp-offchain/std",
+	"sp-runtime/std",
+	"sp-session/std",
+	"sp-std/std",
+	"sp-transaction-pool/std",
+	"sp-version/std",
+	"substrate-wasm-builder",
+	"xcm-builder/std",
+	"xcm-executor/std",
+	"xcm/std",
+]
+
+runtime-benchmarks = [
+	"cumulus-pallet-parachain-system/runtime-benchmarks",
+	"cumulus-pallet-session-benchmarking/runtime-benchmarks",
+	"cumulus-pallet-xcmp-queue/runtime-benchmarks",
+	"cumulus-primitives-utility/runtime-benchmarks",
+	"frame-benchmarking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system-benchmarking/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"hex-literal",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-collator-selection/runtime-benchmarks",
+	"pallet-parachain-template/runtime-benchmarks",
+	"pallet-sudo/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks",
+	"pallet-xcm/runtime-benchmarks",
+	"polkadot-parachain-primitives/runtime-benchmarks",
+	"polkadot-runtime-common/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"xcm-builder/runtime-benchmarks",
+	"xcm-executor/runtime-benchmarks",
+]
+
+try-runtime = [
+	"cumulus-pallet-aura-ext/try-runtime",
+	"cumulus-pallet-dmp-queue/try-runtime",
+	"cumulus-pallet-parachain-system/try-runtime",
+	"cumulus-pallet-xcm/try-runtime",
+	"cumulus-pallet-xcmp-queue/try-runtime",
+	"frame-executive/try-runtime",
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"frame-try-runtime/try-runtime",
+	"pallet-aura/try-runtime",
+	"pallet-authorship/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-collator-selection/try-runtime",
+	"pallet-parachain-template/try-runtime",
+	"pallet-session/try-runtime",
+	"pallet-sudo/try-runtime",
+	"pallet-timestamp/try-runtime",
+	"pallet-transaction-payment/try-runtime",
+	"pallet-xcm/try-runtime",
+	"parachain-info/try-runtime",
+	"polkadot-runtime-common/try-runtime",
+	"sp-runtime/try-runtime",
+]
+
+experimental = [ "pallet-aura/experimental" ]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,6 +16,7 @@
 #[cfg(test)]
 mod tests {
     use crate::versions::get_version_mapping_with_fallback;
+    use crate::versions::Repository;
     use std::{error::Error, path::Path};
 
     async fn verify_version_mapping(
@@ -209,7 +210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
     // To run this test, ensure you have installed the GitHub CLI and are authenticated
     // cause it will fetch the latest release branches from the GitHub API
     async fn works_for_all_versions() {
-        let release_versions = crate::versions::get_release_branches_versions()
+        let release_versions = crate::versions::get_release_branches_versions(Repository::PSDK)
             .await
             .unwrap();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -47,7 +47,7 @@ mod tests {
             .await
             .unwrap();
 
-        let orml_crates_version = get_orml_crates_and_version(crate::DEFAULT_GIT_SERVER, &version).await.unwrap();
+        let orml_crates_version = get_orml_crates_and_version(crate::DEFAULT_GIT_SERVER, &version).await?;
         include_orml_crates_in_version_mapping(&mut crates_versions, orml_crates_version);
 
         // Call the refactored logic function with the test data

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -30,7 +30,7 @@ mod tests {
 
         // Call the refactored logic function with the test data
         let result =
-            crate::update_dependencies_impl(&input_cargo_toml_path, &crates_versions, false, true)
+            crate::update_dependencies_impl(&input_cargo_toml_path, &crates_versions, false, false)
                 .unwrap();
 
         // Assert that the result matches the expected output
@@ -47,7 +47,7 @@ mod tests {
 
         // Call the refactored logic function with the test data
         let result =
-            crate::update_dependencies_impl(&input_cargo_toml_path, &crates_versions, false, false);
+            crate::update_dependencies_impl(&input_cargo_toml_path, &crates_versions, false, true);
 
         result
     }
@@ -210,7 +210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
     // To run this test, ensure you have installed the GitHub CLI and are authenticated
     // cause it will fetch the latest release branches from the GitHub API
     async fn works_for_all_versions() {
-        let release_versions = crate::versions::get_release_branches_versions(Repository::PSDK)
+        let release_versions = crate::versions::get_release_branches_versions(Repository::Psdk)
             .await
             .unwrap();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,7 +15,9 @@
 
 #[cfg(test)]
 mod tests {
+    use crate::versions::get_orml_crates_and_version;
     use crate::versions::get_version_mapping_with_fallback;
+    use crate::versions::include_orml_crates_in_version_mapping;
     use crate::versions::Repository;
     use std::{error::Error, path::Path};
 
@@ -41,15 +43,39 @@ mod tests {
         version: &str,
         input_cargo_toml_path: &Path,
     ) -> Result<Option<String>, Box<dyn Error>> {
-        let crates_versions = get_version_mapping_with_fallback(crate::DEFAULT_GIT_SERVER, version)
+        let mut crates_versions = get_version_mapping_with_fallback(crate::DEFAULT_GIT_SERVER, version)
             .await
             .unwrap();
+
+        let orml_crates_version = get_orml_crates_and_version(crate::DEFAULT_GIT_SERVER, &version).await.unwrap();
+        include_orml_crates_in_version_mapping(&mut crates_versions, orml_crates_version);
 
         // Call the refactored logic function with the test data
         let result =
             crate::update_dependencies_impl(&input_cargo_toml_path, &crates_versions, false, true);
 
         result
+    }
+
+    async fn verify_orml_version_mapping(
+        version: &str,
+        input_cargo_toml_path: &Path,
+        expected_cargo_toml: &str,
+    ) {
+        let mut crates_versions = get_version_mapping_with_fallback(crate::DEFAULT_GIT_SERVER, version)
+            .await
+            .unwrap();
+        
+        let orml_crates_version = get_orml_crates_and_version(crate::DEFAULT_GIT_SERVER, &version).await.unwrap();
+        include_orml_crates_in_version_mapping(&mut crates_versions, orml_crates_version);
+        
+        // Call the refactored logic function with the test data
+        let result =
+            crate::update_dependencies_impl(&input_cargo_toml_path, &crates_versions, false, false)
+                .unwrap();
+        
+        // Assert that the result matches the expected output
+        assert_eq!(result, Some(expected_cargo_toml.into()));
     }
 
     #[tokio::test]
@@ -65,11 +91,25 @@ mod tests {
 
     #[tokio::test]
     // cargo psvm -v 1.14.0 -c
-    // This version doesn't have the Plan.toml file, so it will fallback to Cargo.lock
-    // and check if the versions in the local toml file comply with the Cargo.lock file
+    // This version has the Plan.toml file, so it will not fallback to Cargo.lock
+    // and check if the versions in the local toml file comply with the Plan.toml file
     async fn test_check_version_without_fallback_passes() {
         let input_cargo_toml_path = Path::new("src/testing/plan-toml/check.Cargo.toml");
         let version = "1.14.0";
+
+        let res = verify_version_checking(version, input_cargo_toml_path).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    // cargo psvm -v 1.6.0 -c -O
+    // This version has the Plan.toml file, so it will not fallback to Cargo.lock
+    // and check if the versions in the local toml file comply with the Plan.toml file,
+    // including the ORML crates.
+    async fn test_check_version_with_orml_passes() {
+        let input_cargo_toml_path = Path::new("src/testing/orml/output.Cargo.toml");
+        let version = "1.6.0";
 
         let res = verify_version_checking(version, input_cargo_toml_path).await;
         assert!(res.is_ok());
@@ -116,6 +156,42 @@ mod tests {
         let version = "1.5.0";
 
         verify_version_mapping(version, input_toml_path, expected_output_toml).await;
+    }
+
+    #[tokio::test]
+    // cargo psvm -v 1.6.0 -O
+    // This version is present in the ORML repository, so it will fetch the ORML crates and update
+    // the Cargo.toml file with the new versions
+    async fn test_orml_version_mapping_passes() {
+        let input_cargo_toml_path = Path::new("src/testing/orml/input.Cargo.toml");
+        let output_cargo_toml_path = include_str!("testing/orml/output.Cargo.toml");
+        let version = "1.6.0";
+
+        verify_orml_version_mapping(version, input_cargo_toml_path, output_cargo_toml_path).await;
+    }
+
+    #[tokio::test]
+    // cargo psvm -v 1.14.0 -O
+    // This version is not present in the ORML repository, so it will not fetch the ORML crates and update
+    // the Cargo.toml file with only the polkadot-sdk versions
+    async fn test_orml_mapping_without_branch_passes() {
+        let input_cargo_toml_path = Path::new("src/testing/orml/input.Cargo.toml");
+        let output_cargo_toml_path = include_str!("testing/orml/notOrml.Cargo.toml");
+        let version = "1.14.0";
+
+        verify_orml_version_mapping(version, input_cargo_toml_path, output_cargo_toml_path).await;
+    }
+
+    #[tokio::test]
+    // cargo psvm -v 1.6.0
+    // This version is present in the ORML repository, but the --orml flag isn't supplied so it will not touch
+    // the ORML crates and update the Cargo.toml file with only the polkadot-sdk versions
+    async fn test_orml_mapping_without_flag_passes() {
+        let input_cargo_toml_path = Path::new("src/testing/orml/input.Cargo.toml");
+        let output_cargo_toml_path = include_str!("testing/orml/noFlag.Cargo.toml");
+        let version = "1.6.0";
+
+        verify_version_mapping(version, input_cargo_toml_path, output_cargo_toml_path).await;
     }
 
     #[tokio::test]
@@ -231,7 +307,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
                 &input_cargo_toml_path,
                 &crates_versions,
                 false,
-                true,
+                false,
+            )
+            .unwrap();
+
+            assert!(result.is_some()); // If no changes are made, the result will be None
+        }
+    }
+
+    #[tokio::test]
+    // This test will fetch all available versions, update a generic parachain Cargo.toml file
+    // and assert that the Cargo.toml file has been updated (modified)
+    // This is not exhaustive, but it's a good way to ensure that the logic works for all orml versions
+    // To run this test, ensure you have installed the GitHub CLI and are authenticated
+    // cause it will fetch the latest release branches from the GitHub API
+    async fn works_for_all_orml_versions() {
+        let release_versions = crate::versions::get_release_branches_versions(Repository::Orml)
+            .await
+            .unwrap();
+
+        for version in release_versions {
+            let mut crates_versions =
+                get_version_mapping_with_fallback(crate::DEFAULT_GIT_SERVER, &version)
+                    .await
+                    .unwrap();
+            
+            let orml_crates_version = get_orml_crates_and_version(crate::DEFAULT_GIT_SERVER, &version).await.unwrap();
+            include_orml_crates_in_version_mapping(&mut crates_versions, orml_crates_version);
+
+            assert!(
+                crates_versions.len() > 0,
+                "No versions found for {}",
+                version
+            );
+
+            let input_cargo_toml_path = Path::new("src/testing/orml/input.Cargo.toml");
+            let result = crate::update_dependencies_impl(
+                &input_cargo_toml_path,
+                &crates_versions,
+                false,
+                false,
             )
             .unwrap();
 

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -42,15 +42,6 @@ pub struct Crate {
     pub publish: Option<bool>,
 }
 
-// pub async fn update_orml_crates_version(
-//     version: &str,
-//     dep_table: &mut toml_edit::Table,
-//     crates_versions: &BTreeMap<String, String>,
-//     overwrite: bool
-// ) -> Result<(), Box<dyn std::error::Error>> {
-
-// }
-
 pub async fn get_orml_crates_and_version(
     base_url: &str,
     version: &str,

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -42,6 +42,93 @@ pub struct Crate {
     pub publish: Option<bool>,
 }
 
+// pub async fn update_orml_crates_version(
+//     version: &str,
+//     dep_table: &mut toml_edit::Table,
+//     crates_versions: &BTreeMap<String, String>,
+//     overwrite: bool
+// ) -> Result<(), Box<dyn std::error::Error>> {
+
+// }
+
+pub async fn get_orml_crates_and_version(
+    base_url: &str,
+    version: &str,
+) -> Result<Option<(Vec<String>, String)>, Box<dyn std::error::Error>> {
+    if get_release_branches_versions(Repository::Orml)
+        .await?
+        .contains(&version.to_string())
+    {
+        let version_url = format!(
+            "{}/open-web3-stack/open-runtime-module-library/polkadot-v{}/Cargo.dev.toml",
+            base_url, version
+        );
+        let response = reqwest::Client::new()
+            .get(&version_url)
+            .header("User-Agent", "reqwest")
+            .header("Accept", "application/vnd.github.v3+json")
+            .send()
+            .await?;
+
+        let content = response.text().await?;
+
+        Ok(Some(parse_orml_workspace_members(&content)))
+    } else {
+        log::error!(
+            "No matching ORML release version found for corresponding polkadot-sdk version."
+        );
+        Ok(None)
+    }
+}
+
+fn parse_orml_workspace_members(toml_content: &str) -> (Vec<String>, String) {
+    let mut members = Vec::new();
+    let mut crates_version = String::new();
+    let mut in_workspace_members = false;
+
+    for line in toml_content.lines() {
+        if line.trim() == "[workspace]" {
+            in_workspace_members = true;
+            continue;
+        }
+
+        if line.trim().starts_with("# crates-version = \"") {
+            crates_version = line
+                .trim()
+                .replace("# crates-version = \"", "")
+                .trim_matches('"')
+                .to_string();
+            break;
+        }
+
+        if in_workspace_members {
+            if line.trim().starts_with("members = [") {
+                continue;
+            } else if line.trim().ends_with(']') {
+                in_workspace_members = false;
+            } else if line.contains('/') {
+                continue;
+            } else {
+                let member = line.trim().trim_matches(',').trim_matches('"');
+                members.push(format!("orml-{}", member));
+            }
+        }
+    }
+
+    (members, crates_version)
+}
+
+pub fn include_orml_crates_in_version_mapping(
+    crates_versions: &mut BTreeMap<String, String>,
+    orml_crates_version: Option<(Vec<String>, String)>,
+) {
+    if let Some((orml_crates, orml_version)) = orml_crates_version {
+        for crate_name in orml_crates {
+            crates_versions.insert(crate_name, orml_version.clone());
+        }
+    }
+}
+
 pub async fn get_version_mapping_with_fallback(
     base_url: &str,
     version: &str,
@@ -82,7 +169,6 @@ pub async fn get_version_mapping(
         .header("Accept", "application/vnd.github.v3+json")
         .send()
         .await?;
-
     let content = response.text().await?;
 
     match source {
@@ -150,25 +236,25 @@ struct RepositoryInfo {
     branches_url: String,
     gh_cmd_url: String,
     version_filter_string: String,
-    version_replace_string: String
+    version_replace_string: String,
 }
 
 pub enum Repository {
     /// The official ORML repository
-    ORML,
+    Orml,
     /// The official Polkadot SDK repository
-    PSDK
+    Psdk,
 }
 
 fn get_repository_info(repository: &Repository) -> RepositoryInfo {
     match repository {
-        Repository::ORML => RepositoryInfo {
+        Repository::Orml => RepositoryInfo {
             branches_url: "https://api.github.com/repos/open-web3-stack/open-runtime-module-library/branches?per_page=100&page=".into(),
             gh_cmd_url: "/repos/open-web3-stack/open-runtime-module-library/branches?per_page=100&page=".into(),
             version_filter_string: "polkadot-v1".into(),
             version_replace_string: "polkadot-v".into()
         },
-        Repository::PSDK => RepositoryInfo {
+        Repository::Psdk => RepositoryInfo {
             branches_url: "https://api.github.com/repos/paritytech/polkadot-sdk/branches?per_page=100&page=".into(),
             gh_cmd_url: "/repos/paritytech/polkadot-sdk/branches/per_page=100&page={}".into(),
             version_filter_string: "release-crates-io-v".into(),
@@ -184,11 +270,11 @@ pub async fn get_release_branches_versions(repository: Repository) -> Result<Vec
     for page in 1..100 {
         // currently there's 5 pages, so 100 should be enough
         let response = reqwest::Client::new()
-        .get(format!("{}{}",repository_info.branches_url, page))
-        .header("User-Agent", "reqwest")
-        .header("Accept", "application/vnd.github.v3+json")
-        .send()
-        .await?;
+            .get(format!("{}{}", repository_info.branches_url, page))
+            .header("User-Agent", "reqwest")
+            .header("Accept", "application/vnd.github.v3+json")
+            .send()
+            .await?;
 
         let output = if response.status().is_success() {
             response.text().await?
@@ -217,7 +303,7 @@ pub async fn get_release_branches_versions(repository: Repository) -> Result<Vec
         let version_branches = branches
             .iter()
             .filter(|b| b.name.starts_with(&repository_info.version_filter_string))
-            .filter(|b| !(b.name == "polkadot-v1.0.0"))
+            .filter(|b| (b.name != "polkadot-v1.0.0"))
             .map(|branch| branch.name.replace(&repository_info.version_replace_string, ""));
 
         release_branches = release_branches

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -16,36 +16,118 @@
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashSet};
 
+/// Represents the structure of a Cargo.lock file, including all packages.
 #[derive(Debug, Deserialize)]
 struct CargoLock {
+    /// A list of packages included in the Cargo.lock file.
     package: Vec<Package>,
 }
 
+/// Represents a single package within a Cargo.lock file.
 #[derive(Debug, Deserialize)]
 struct Package {
+    /// The name of the package.
     name: String,
+    /// The version of the package.
     version: String,
+    /// The source from which the package was retrieved(usually GitHub), if any.
     source: Option<String>,
 }
 
+/// Represents the structure of a Plan.toml file, with all crates.
 #[derive(Debug, Deserialize)]
 pub struct PlanToml {
+    /// A list of crates included in the Plan.toml file.
     #[serde(rename = "crate")]
     pub crates: Vec<Crate>,
 }
 
+/// Represents a single crate within a Plan.toml file.
 #[derive(Debug, Deserialize)]
 pub struct Crate {
+    /// The name of the crate.
     pub name: String,
+    /// The version the crate is updating to.
     pub to: String,
+    /// The current version of the crate.
     pub from: String,
+    /// Indicates if the crate should be published.
     pub publish: Option<bool>,
 }
 
+/// Represents the structure of an Orml.toml file with workspace information.
+#[derive(Debug, Deserialize)]
+pub struct OrmlToml {
+    /// The workspace information.
+    pub workspace: Workspace,
+}
+
+/// Represents the metadata section within a workspace.
+#[derive(Deserialize, Debug)]
+pub struct Metadata {
+    /// ORML specific metadata.
+    orml: Orml,
+}
+
+/// Represents ORML specific metadata.
+#[derive(Deserialize, Debug)]
+pub struct Orml {
+    /// The version of the crates managed by ORML.
+    #[serde(rename = "crates-version")]
+    crates_version: String,
+}
+
+/// Represents a workspace, including its members and metadata.
+#[derive(Deserialize, Debug)]
+pub struct Workspace {
+    /// A list of members (crates) in the workspace.
+    members: Vec<String>,
+    /// Metadata associated with the workspace.
+    metadata: Metadata,
+}
+
+/// Fetches the ORML crates and their versions for a specific version of Polkadot.
+///
+/// This function queries a repository for a specific version of the ORML crates,
+/// attempting to retrieve the `Cargo.dev.toml` file that lists the ORML workspace members
+/// and the corresponding crates version. It uses the provided `base_url` and `version` to 
+/// construct the URL for the request.
+///
+/// # Arguments
+///
+/// * `base_url` - The base URL of GitHub.
+/// * `version` - The release version of the Polkadot-sdk for which ORML crates' versions are being fetched.
+///
+/// # Returns
+///
+/// Returns `Ok(Some(OrmlToml))` if the `Cargo.dev.toml` file is successfully retrieved and parsed,
+/// indicating the ORML crates and their versions. Returns `Ok(None)` if no matching ORML release
+/// version is found for the corresponding Polkadot version. In case of any error during the
+/// fetching or parsing process, an error is returned.
+///
+/// # Errors
+///
+/// This function returns an error if there is any issue with the HTTP request, response parsing,
+/// or if the required fields are not found in the `Cargo.dev.toml` file.
+///
+/// # Examples
+///
+/// ```
+/// #[tokio::main]
+/// async fn main() {
+///     let base_url = "https://raw.githubusercontent.com";
+///     let version = "1.12.0";
+///     match get_orml_crates_and_version(base_url, version).await {
+///         Ok(Some(orml_toml)) => println!("ORML crates: {:?}", orml_toml),
+///         Ok(None) => println!("No matching ORML version found."),
+///         Err(e) => println!("Error fetching ORML crates: {}", e),
+///     }
+/// }
+/// ```
 pub async fn get_orml_crates_and_version(
     base_url: &str,
     version: &str,
-) -> Result<Option<(Vec<String>, String)>, Box<dyn std::error::Error>> {
+) -> Result<Option<OrmlToml>, Box<dyn std::error::Error>> {
     if get_release_branches_versions(Repository::Orml)
         .await?
         .contains(&version.to_string())
@@ -63,7 +145,9 @@ pub async fn get_orml_crates_and_version(
 
         let content = response.text().await?;
 
-        Ok(Some(parse_orml_workspace_members(&content)))
+        let orml_workspace_members = toml::from_str::<OrmlToml>(&content)
+            .map_err(|_| return "Error Parsing ORML TOML. Required Fields not Found")?;
+        Ok(Some(orml_workspace_members))
     } else {
         log::error!(
             "No matching ORML release version found for corresponding polkadot-sdk version."
@@ -72,50 +156,36 @@ pub async fn get_orml_crates_and_version(
     }
 }
 
-fn parse_orml_workspace_members(toml_content: &str) -> (Vec<String>, String) {
-    let mut members = Vec::new();
-    let mut crates_version = String::new();
-    let mut in_workspace_members = false;
-
-    for line in toml_content.lines() {
-        if line.trim() == "[workspace]" {
-            in_workspace_members = true;
-            continue;
-        }
-
-        if line.trim().starts_with("# crates-version = \"") {
-            crates_version = line
-                .trim()
-                .replace("# crates-version = \"", "")
-                .trim_matches('"')
-                .to_string();
-            break;
-        }
-
-        if in_workspace_members {
-            if line.trim().starts_with("members = [") {
-                continue;
-            } else if line.trim().ends_with(']') {
-                in_workspace_members = false;
-            } else if line.contains('/') {
-                continue;
-            } else {
-                let member = line.trim().trim_matches(',').trim_matches('"');
-                members.push(format!("orml-{}", member));
-            }
-        }
-    }
-
-    (members, crates_version)
-}
-
+/// Includes ORML crates in the version mapping.
+///
+/// This function updates a given version mapping (`BTreeMap`) by adding the versions of ORML 
+/// crates obtained from a `OrmlToml` instance. It prefixes each crate name with "orml-" and 
+/// inserts the corresponding version into the map. If the `orml_crates_version` is `None`, 
+/// the function does nothing.
+///
+/// # Arguments
+///
+/// * `crates_versions` - A mutable reference to a `BTreeMap` where the original polkadot-sdk 
+///   crate names and versions are stored.
+/// * `orml_crates_version` - An `Option<OrmlToml>` that may contain the ORML crates and their
+///   versions.
+///
+/// # Examples
+///
+/// ```
+/// let mut version_map: BTreeMap<String, String> = BTreeMap::new();
+/// include_orml_crates_in_version_mapping(&mut version_map, Some(orml_toml));
+/// ```
 pub fn include_orml_crates_in_version_mapping(
     crates_versions: &mut BTreeMap<String, String>,
-    orml_crates_version: Option<(Vec<String>, String)>,
+    orml_crates_version: Option<OrmlToml>,
 ) {
-    if let Some((orml_crates, orml_version)) = orml_crates_version {
-        for crate_name in orml_crates {
-            crates_versions.insert(crate_name, orml_version.clone());
+    if let Some(orml_toml) = orml_crates_version {
+        for crate_name in orml_toml.workspace.members {
+            crates_versions.insert(
+                format!("orml-{}",crate_name),
+                orml_toml.workspace.metadata.orml.crates_version.clone(),
+            );
         }
     }
 }
@@ -134,18 +204,17 @@ pub async fn get_version_mapping_with_fallback(
     }
 }
 
-fn version_to_url(
-    base_url: &str,
-    version: &str,
-    source: &str,
-) -> String {
+fn version_to_url(base_url: &str, version: &str, source: &str) -> String {
     let version = if version.starts_with("stable") {
         version.into()
     } else {
         format!("release-crates-io-v{}", version)
     };
 
-    format!("{}/paritytech/polkadot-sdk/{}/{}", base_url, version, source)
+    format!(
+        "{}/paritytech/polkadot-sdk/{}/{}",
+        base_url, version, source
+    )
 }
 
 pub async fn get_version_mapping(
@@ -217,15 +286,27 @@ async fn get_plan_packages(
     Ok(plan_packages)
 }
 
+/// Represents a single branch in a repository.
+///
+/// This struct is used to deserialize JSON data from a repository's branch list.
 #[derive(serde::Deserialize, Debug)]
 struct Branch {
+    /// The name of the branch.
     name: String,
 }
 
+/// Contains information about a repository.
+///
+/// This struct holds various URLs and strings used to interact with a repository,
+/// including fetching branches and processing version information.
 struct RepositoryInfo {
+    /// The URL to fetch branch information from the repository.
     branches_url: String,
+    /// The URL for GitHub commands related to the repository.
     gh_cmd_url: String,
+    /// A string used to filter versions from branch names.
     version_filter_string: String,
+    /// A string used to replace parts of the version string if necessary.
     version_replace_string: String,
 }
 
@@ -253,7 +334,47 @@ fn get_repository_info(repository: &Repository) -> RepositoryInfo {
     }
 }
 
-pub async fn get_release_branches_versions(repository: Repository) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+/// Fetches the versions of release branches from a repository.
+///
+/// This asynchronous function queries a repository for its branches and filters out those
+/// that match a specific versioning pattern. It supports fetching data via HTTP requests
+/// and, in case of failure, falls back to querying the GitHub API using the `gh` command-line tool.
+///
+/// # Arguments
+///
+/// * `repository` - A `Repository` enum specifying whether to query the ORML or Polkadot SDK repository.
+///
+/// # Returns
+///
+/// Returns a `Result` containing either a vector of version strings on success or an error on failure.
+///
+/// # Errors
+///
+/// This function can return an error in several cases, including but not limited to:
+/// - Network failures during the HTTP request.
+/// - JSON parsing errors when deserializing the response into `Branch` structs.
+/// - UTF-8 decoding errors when processing the output of the `gh` command.
+/// - I/O errors when executing the `gh` command.
+///
+/// # Examples
+///
+/// ```no_run
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let orml_repository = Repository::Orml;
+///     let orml_versions = get_release_branches_versions(orml_repository).await?;
+///     println!("Orml Release versions: {:?}", orml_versions);
+/// 
+///     let psdk_repository = Repository::Psdk;
+///     let psdk_versions = get_release_branches_versions(psdk_repository).await?;
+///     println!("Polkadot-sdk Release versions: {:?}", psdk_versions);
+/// 
+///     Ok(())
+/// }
+/// ```
+pub async fn get_release_branches_versions(
+    repository: Repository,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let mut release_branches = vec![];
     let repository_info = get_repository_info(&repository);
 
@@ -278,10 +399,7 @@ pub async fn get_release_branches_versions(repository: Repository) -> Result<Vec
                         "Accept: application/vnd.github+json",
                         "-H",
                         "X-GitHub-Api-Version: 2022-11-28",
-                        &format!(
-                            "{}{}",
-                            repository_info.gh_cmd_url, page
-                        ),
+                        &format!("{}{}", repository_info.gh_cmd_url, page),
                     ])
                     .output()?
                     .stdout,
@@ -293,8 +411,12 @@ pub async fn get_release_branches_versions(repository: Repository) -> Result<Vec
         let version_branches = branches
             .iter()
             .filter(|b| b.name.starts_with(&repository_info.version_filter_string))
-            .filter(|b| (b.name != "polkadot-v1.0.0"))
-            .map(|branch| branch.name.replace(&repository_info.version_replace_string, ""));
+            .filter(|b| (b.name != "polkadot-v1.0.0")) // This is in place to filter that particular orml version as it is not a valid polkadot-sdk release version
+            .map(|branch| {
+                branch
+                    .name
+                    .replace(&repository_info.version_replace_string, "")
+            });
 
         release_branches = release_branches
             .into_iter()
@@ -329,10 +451,7 @@ pub async fn get_parity_crate_owner_crates() -> Result<HashSet<String>, Box<dyn 
 
         let crates_data: serde_json::Value = serde_json::from_str(&output)?;
 
-        let crates = crates_data["crates"]
-            .as_array()
-            .unwrap()
-            .iter();
+        let crates = crates_data["crates"].as_array().unwrap().iter();
 
         let crates_len = crates.len();
 

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -222,7 +222,6 @@ struct Branch {
     name: String,
 }
 
-#[derive(Default)]
 struct RepositoryInfo {
     branches_url: String,
     gh_cmd_url: String,


### PR DESCRIPTION
This PR introduces a new `--orml` flag to the CLI tool, enabling users to view the available ORML versions with respect to the released Polkadot-sdk versions and update the ORML dependencies in the local `Cargo.toml` if present. This only logs an error if the supplied version isn't found in the ORML releases but doesn't exit with a non-zero exit code.

Key Features:

1. ORML Version Viewing: When the `--orml` flag is used with the `--list` flag, users can now see all the available ORML versions that are compatible with the corresponding Polkadot-sdk versions.

2.  ORML Version Updating: When the `--orml` flag is used with the `--version` flag, users can now update their ORML dependencies in the `Cargo.toml` file if the version is available in the ORML releases, else those dependencies remain untouched and users can resolve those manually.

3. Compatible with the previous `--check` flag update: When the `--orml` flag is used with the `--check` flag, users can simply compare and check if their dependencies(including the ORML crates) match the expected versions, without actually updating the `Cargo.toml`

polkadot address: 16SGUEfpDop2fXi9K89yzCQWHJ3vHz1tKJVA1pCBjoew5tzP