### PR TITLE
Added local caching mechanism for list of polkadot-sdk versions to fasten fetch time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
+name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +600,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +855,7 @@ name = "psvm"
 version = "0.2.4"
 dependencies = [
  "clap",
+ "dirs",
  "env_logger",
  "log",
  "mockito",
@@ -884,6 +915,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1176,6 +1218,26 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1493,6 +1555,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "psvm"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psvm"
-version = "0.2.4"
+version = "0.2.5"
 description = "A tool to manage and update the Polkadot SDK dependencies in any Cargo.toml file."
 repository = "https://github.com/paritytech/psvm"
 authors = ["Parity Technologies <admin@parity.io>", "Patricio (patriciobcs)"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ env_logger = "0.11.3"
 reqwest = { version = "0.12.3", features = ["json"] }
 toml = "0.8.12"
 tokio = { version = "1.37.0", features = ["full"] }
+dirs = "3.0"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ If you want to check if the dependencies in your local Cargo.toml file are match
 
 If you want to update the ORML crates in your local Cargo.toml, you can use the `-O` or `--orml` flag along with the `--version` flag to update the ORML crates along with the polkadot-sdk crates. This works only if the supplied version is present in the ORML releases.
 
+If you want to fetch available polkadot-sdk versions from a local cache, or want to just cache the versions list if using for the first time, you can use the `-C` or `--cache` flag alongside the `--list` flag.
+
+If you want to update the local cache with a freshly fetched list of versions from GitHub, you can use the `-u` or `--update-cache` flag.
+
 ```sh
 # Go to the directory containing the Cargo.toml file you want to update
 cd <cargo-toml-dir>
@@ -43,6 +47,10 @@ psvm -l
 psvm -v "1.4.0" -c
 # Update the ORML dependencies along with the Polkadot SDK dependencies.
 psvm -v "1.6.0" -O
+# Update the local cache with freshly fetched list of versions from GitHub
+psvm -u
+# Fetch the list of versions from the local cache
+psvm --list --cache
 ```
 
 > Listing all available Polkadot SDK versions requires querying the GitHub API, so your IP may be rate-limited. If a rate limit is reached, the tool will fallback to the GitHub CLI to list the versions. Ensure you have the GitHub CLI installed and authenticated to avoid any issue.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,8 +1,8 @@
+use crate::versions::get_polkadot_sdk_versions;
+use serde::{Deserialize, Serialize};
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use serde::{Serialize, Deserialize};
-use crate::versions::get_polkadot_sdk_versions;
 
 /// The structure to hold the cached list of versions
 #[derive(Serialize, Deserialize, Debug)]
@@ -76,10 +76,11 @@ fn get_cache_directory() -> Option<PathBuf> {
 ///     }
 /// }
 /// ```
-pub async fn get_polkadot_sdk_versions_from_cache() -> Result<Vec<String>, Box<dyn std::error::Error>> {
+pub async fn get_polkadot_sdk_versions_from_cache(
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     // Path to the cache file. should save as a constant once path is finalized
     let cache_path = get_cache_directory().unwrap(); // Can unwrap because we know the cache directory exists
-    // Attempt to load the cache
+                                                     // Attempt to load the cache
     let cache = Cache::load(&cache_path);
 
     let data = if let Ok(cache) = cache {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,83 @@
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+use serde::{Serialize, Deserialize};
+use crate::versions::get_polkadot_sdk_versions;
+
+/// The structure to hold the cached list of versions
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct Cache {
+    /// Data to be cached
+    pub data: Vec<String>,
+}
+
+impl Cache {
+    // Load cache from a file
+    pub fn load(path: &PathBuf) -> io::Result<Self> {
+        let mut file = File::open(path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        let cache: Cache = serde_json::from_str(&contents)?;
+        Ok(cache)
+    }
+
+    // Save cache to a file
+    pub fn save(&self, path: &PathBuf) -> io::Result<()> {
+        let contents = serde_json::to_string(&self)?;
+        let mut file = File::create(path)?;
+        file.write_all(contents.as_bytes())?;
+        Ok(())
+    }
+}
+
+/// Retrieves the list of Polkadot SDK versions, either from a local cache or by fetching them anew.
+///
+/// This function first attempts to load the list of Polkadot SDK versions from a local cache file.
+/// If the cache file exists and can be loaded, the cached data is returned. If the cache does not exist,
+/// is unreadable, or any other error occurs during loading, the function logs an error message,
+/// fetches the list of versions by calling `get_polkadot_sdk_versions`, caches the newly fetched list,
+/// and then returns it.
+///
+/// # Returns
+/// A `Result` wrapping a vector of strings, where each string is a version of the Polkadot SDK.
+/// If the operation is successful, `Ok(Vec<String>)` is returned, containing the list of versions.
+/// If an error occurs during fetching new versions or saving them to the cache, an error is returned
+/// wrapped in `Err(Box<dyn std::error::Error>)`.
+///
+/// # Errors
+/// This function can return an error in several cases, including but not limited to:
+/// - Failure to read the cache file due to permissions or file not found.
+/// - Failure to write to the cache file, possibly due to permissions issues.
+/// - Errors returned by `get_polkadot_sdk_versions` during the fetching process.
+///
+/// # Examples
+/// ```
+/// #[tokio::main]
+/// async fn main() {
+///     match get_polkadot_sdk_versions_from_cache().await {
+///         Ok(versions) => println!("Polkadot SDK Versions: {:?}", versions),
+///         Err(e) => eprintln!("Failed to get Polkadot SDK versions: {}", e),
+///     }
+/// }
+/// ```
+pub async fn get_polkadot_sdk_versions_from_cache() -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    // Path to the cache file. should save as a constant once path is finalized
+    let cache_path = PathBuf::from("./cache.json");
+
+    // Attempt to load the cache
+    let cache = Cache::load(&cache_path);
+
+    let data = if let Ok(cache) = cache {
+        cache.data
+    } else {
+        log::error!("Cache file doesn't exist or failed to load, fetching new data");
+        let new_data = get_polkadot_sdk_versions().await?;
+        let new_cache = Cache {
+            data: new_data.clone(),
+        };
+        new_cache.save(&cache_path)?;
+        new_data
+    };
+
+    Ok(data)
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -37,7 +37,7 @@ impl Cache {
     }
 }
 
-fn get_cache_directory() -> Option<PathBuf> {
+pub fn get_cache_directory() -> Option<PathBuf> {
     if let Some(cache_dir) = dirs::cache_dir() {
         let app_cache_dir = cache_dir.join("psvm/cache.json");
         Some(app_cache_dir)
@@ -78,9 +78,9 @@ fn get_cache_directory() -> Option<PathBuf> {
 /// ```
 pub async fn get_polkadot_sdk_versions_from_cache(
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
-    // Path to the cache file. should save as a constant once path is finalized
-    let cache_path = get_cache_directory().unwrap(); // Can unwrap because we know the cache directory exists
-                                                     // Attempt to load the cache
+    // Can unwrap because we know the cache directory exists
+    let cache_path = get_cache_directory().unwrap();
+    // Attempt to load the cache
     let cache = Cache::load(&cache_path);
 
     let data = if let Ok(cache) = cache {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,9 @@ use versions::{
     get_version_mapping_with_fallback, include_orml_crates_in_version_mapping, Repository,
 };
 
-use cache::get_polkadot_sdk_versions_from_cache;
+use cache::{get_cache_directory, get_polkadot_sdk_versions_from_cache};
 
 pub const DEFAULT_GIT_SERVER: &str = "https://raw.githubusercontent.com";
-pub const DEFAULT_CACHE_PATH: &str = "./target/cache.json";
 
 /// Polkadot SDK Version Manager.
 ///
@@ -87,9 +86,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if cmd.update_cache {
         log::info!("Updating cache by freshly fetching versions from GitHub");
         let versions = get_polkadot_sdk_versions().await?;
-        let cache_path = PathBuf::from("./cache.json");
+        let cache_dir = if let Some(cache_directory) = get_cache_directory() {
+            cache_directory
+        } else {
+            return Err("Could not determine cache directory".into());
+        };
         let cache = cache::Cache { data: versions };
-        cache.save(&cache_path)?;
+        cache.save(&cache_dir)?;
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod cache;
 mod tests;
 mod versions;
-mod cache;
 
 use clap::Parser;
 use env_logger::Env;
@@ -46,7 +46,12 @@ struct Command {
     path: PathBuf,
 
     /// Specifies the Polkadot SDK version. Use '--list' flag to display available versions.
-    #[clap(short, long, required_unless_present = "list", required_unless_present = "update_cache")]
+    #[clap(
+        short,
+        long,
+        required_unless_present = "list",
+        required_unless_present = "update_cache"
+    )]
     version: Option<String>,
 
     /// Overwrite local dependencies (using path) with same name as the ones in the Polkadot SDK.
@@ -83,9 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         log::info!("Updating cache by freshly fetching versions from GitHub");
         let versions = get_polkadot_sdk_versions().await?;
         let cache_path = PathBuf::from("./cache.json");
-        let cache = cache::Cache {
-            data: versions,
-        };
+        let cache = cache::Cache { data: versions };
         cache.save(&cache_path)?;
         return Ok(());
     }
@@ -94,12 +97,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         if cmd.orml {
             print_version_list(get_release_branches_versions(Repository::Orml).await?);
         } else if cmd.cache {
-                log::info!("Reading versions from cache");
-                print_version_list(get_polkadot_sdk_versions_from_cache().await?);
+            log::info!("Reading versions from cache");
+            print_version_list(get_polkadot_sdk_versions_from_cache().await?);
         } else {
-                log::info!("Fetching versions from GitHub");
-                print_version_list(get_polkadot_sdk_versions().await?);
-            }
+            log::info!("Fetching versions from GitHub");
+            print_version_list(get_polkadot_sdk_versions().await?);
+        }
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ use versions::{
 use cache::get_polkadot_sdk_versions_from_cache;
 
 pub const DEFAULT_GIT_SERVER: &str = "https://raw.githubusercontent.com";
+pub const DEFAULT_CACHE_PATH: &str = "./target/cache.json";
 
 /// Polkadot SDK Version Manager.
 ///
@@ -92,15 +93,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if cmd.list {
         if cmd.orml {
             print_version_list(get_release_branches_versions(Repository::Orml).await?);
-        } else {
-            if cmd.cache {
+        } else if cmd.cache {
                 log::info!("Reading versions from cache");
                 print_version_list(get_polkadot_sdk_versions_from_cache().await?);
-            } else {
+        } else {
                 log::info!("Fetching versions from GitHub");
                 print_version_list(get_polkadot_sdk_versions().await?);
             }
-        }
         return Ok(());
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -106,7 +106,9 @@ mod tests {
     async fn test_overwriting_cache_works() {
         let cache_file_path: PathBuf = PathBuf::from("src/testing/cache.json");
         let cache_data = get_polkadot_sdk_versions().await.unwrap();
-        let cache = Cache { data: cache_data.clone() };
+        let cache = Cache {
+            data: cache_data.clone(),
+        };
         let res = cache.save(&cache_file_path);
         assert!(res.is_ok());
         assert_eq!(res.unwrap(), ());
@@ -144,7 +146,10 @@ mod tests {
 
         let loaded_cache_data = Cache::load(&cache_file_path);
         assert!(loaded_cache_data.is_err());
-        assert!(loaded_cache_data.unwrap_err().to_string().contains("No such file or directory"));
+        assert!(loaded_cache_data
+            .unwrap_err()
+            .to_string()
+            .contains("No such file or directory"));
     }
 
     #[tokio::test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -88,8 +88,7 @@ mod tests {
     }
 
     #[tokio::test]
-    // This version has the Plan.toml file, so it will not fallback to Cargo.lock
-    // and check if the versions in the local toml file comply with the Plan.toml file
+    // Save the Polkadot SDK versions in a cache file
     async fn test_saving_cache_works() {
         let cache_file_path: PathBuf = PathBuf::from("src/testing/cache.json");
         let cache_data = get_polkadot_sdk_versions().await.unwrap();
@@ -103,8 +102,7 @@ mod tests {
     }
 
     #[tokio::test]
-    // This version has the Plan.toml file, so it will not fallback to Cargo.lock
-    // and check if the versions in the local toml file comply with the Plan.toml file
+    // Caches the Polkadot SDK versions in a file, then overwrites the cache with the same data
     async fn test_overwriting_cache_works() {
         let cache_file_path: PathBuf = PathBuf::from("src/testing/cache.json");
         let cache_data = get_polkadot_sdk_versions().await.unwrap();
@@ -123,8 +121,7 @@ mod tests {
     }
 
     #[tokio::test]
-    // This version has the Plan.toml file, so it will not fallback to Cargo.lock
-    // and check if the versions in the local toml file comply with the Plan.toml file
+    // Loads the data from the cache file and checks if it matches the data that was cached
     async fn test_loading_cache_works() {
         let cache_file_path: PathBuf = PathBuf::from("src/testing/cache.json");
         let cache_data = get_polkadot_sdk_versions().await.unwrap();
@@ -141,8 +138,7 @@ mod tests {
     }
 
     #[tokio::test]
-    // This version has the Plan.toml file, so it will not fallback to Cargo.lock
-    // and check if the versions in the local toml file comply with the Plan.toml file
+    // Tries to load the cache from a nonexistent file, which should fail
     async fn test_loading_cache_from_nonexistent_file_fails() {
         let cache_file_path: PathBuf = PathBuf::from("non/existing/path/cache.json");
 

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -309,7 +309,6 @@ fn version_to_url(base_url: &str, version: &str, source: &str) -> String {
         format!("release-crates-io-v{}", version)
     };
 
-    println!("{}", format!("{}/paritytech/polkadot-sdk/{}/{}", base_url, version, source));
     format!(
         "{}/paritytech/polkadot-sdk/{}/{}",
         base_url, version, source


### PR DESCRIPTION
This PR introduces a `--cache` flag to locally store the list of polkadot-sdk versions to exponentially fasten their fetch time compared to the GitHub API or CLI. A `--update-cache` flag is also added to just update the local cache by freshly fetching the available versions from GitHub.

Key Features:

1. Cache the versions list to fetch the versions lightning-fast
2. Update the local cache by freshly fetching versions list from GitHub