### PR TITLE
feat: set github token authorization in request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ psvm -v "1.4.0" -c
 psvm -v "1.6.0" -O
 ```
 
-> Listing all available Polkadot SDK versions requires querying the GitHub API, so your IP may be rate-limited. If a rate limit is reached, the tool will fallback to the GitHub CLI to list the versions. Ensure you have the GitHub CLI installed and authenticated to avoid any issue.
+> Listing all available Polkadot SDK versions requires querying the GitHub API, so your IP may be rate-limited. If a rate limit is reached, the tool will fallback to the GitHub CLI to list the versions. Ensure you have the GitHub CLI installed and authenticated to avoid any issue, or you can alternatively set the `GITHUB_TOKEN` environment variable to your GitHub API token.
 
 ## Using as a Library
 


### PR DESCRIPTION
This PR places the corresponding github authorization HTTP header if the `GITHUB_TOKEN` environment variable is present. This avoids the need to fallback to the `gh` binary.

Since I was on it, I created a `github_query` helper function to make the code cleaner.